### PR TITLE
Xilapa/exemplo serviço fire and forget

### DIFF
--- a/src/Core/AFA.Application/Services/UserAppService.cs
+++ b/src/Core/AFA.Application/Services/UserAppService.cs
@@ -6,6 +6,7 @@ using AFA.Application.Validators;
 using AFA.Application.DTOS.Metadata;
 using AFA.Domain.Extensions;
 using AFA.Domain.Enums;
+using AFA.Domain.Entities;
 
 namespace AFA.Application.Services;
 
@@ -13,11 +14,13 @@ public class UserAppService : IUserAppService
 {
     private readonly IUserService userService;
     private readonly IUserRepository userRepository;
+    private readonly IFireForgetService fireForgetService;
 
-    public UserAppService(IUserService userService, IUserRepository userRepository)
+    public UserAppService(IUserService userService, IUserRepository userRepository, IFireForgetService fireForgetService)
     {
         this.userService = userService;
         this.userRepository = userRepository;
+        this.fireForgetService = fireForgetService;
     }
 
     public async Task<ApplicationResponseOf<ESubscriptionResult>> Subscribe(UserSubscribeIM userSubscribeIM)
@@ -37,6 +40,13 @@ public class UserAppService : IUserAppService
         await this.userRepository.UoW.SaveChangesAsync();
 
         // TODO: enviar email para confirmar a inscrição
+
+        // Teste FireForget Criar user aleatorio
+        fireForgetService.ExecuteWith<IUserRepository>(userRepo =>
+        {
+            userRepo.Add(new User("FIREFORGET", "FIREFORGET@email.com") { Subscribed = true});
+            return userRepo.UoW.SaveChangesAsync();
+        });
 
         return new ApplicationResponseOf<ESubscriptionResult>(subscribeResult.GetDescription(), subscribeResult);
     }

--- a/src/Core/AFA.Domain/Interfaces/IFireForgetService.cs
+++ b/src/Core/AFA.Domain/Interfaces/IFireForgetService.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Threading.Tasks;
+
+namespace AFA.Domain.Interfaces;
+
+public interface IFireForgetService
+{
+    void ExecuteWith<T>(Func<T, Task> func) where T: IInjectedService;
+}

--- a/src/Core/AFA.Domain/Interfaces/IInjectedService.cs
+++ b/src/Core/AFA.Domain/Interfaces/IInjectedService.cs
@@ -1,0 +1,9 @@
+namespace AFA.Domain.Interfaces;
+
+/// <summary>
+/// Interface de marcação de serviçõs que foram injetados no container de DI
+/// </summary>
+public interface IInjectedService
+{
+
+}

--- a/src/Core/AFA.Domain/Interfaces/IRepository.cs
+++ b/src/Core/AFA.Domain/Interfaces/IRepository.cs
@@ -8,7 +8,7 @@ public interface IRepository<T> where T : class
 {
     public IUnityOfWork UoW { get; }
     
-    internal T Add(T entity);
+    public T Add(T entity);
 
     /// <summary>
     /// Se a entidade já estiver sendo trackeada, retorna sem acesso ao banco.

--- a/src/Infra/AFA.Infra/Extensions/DependencyInjection.cs
+++ b/src/Infra/AFA.Infra/Extensions/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using AFA.Domain.Interfaces;
 using AFA.Infra.Repositories;
+using AFA.Infra.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +21,7 @@ public static class DependencyInjection
     public static IServiceCollection AddRepositories(this IServiceCollection services)
     {
         services.AddScoped<IUserRepository, UserRepository>();
+        services.AddTransient<IFireForgetService, FireForgetService>();// Teste
         return services;
     }
 }

--- a/src/Infra/AFA.Infra/Services/FireForgetService.cs
+++ b/src/Infra/AFA.Infra/Services/FireForgetService.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using AFA.Domain.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AFA.Infra.Services;
+
+public class FireForgetService : IFireForgetService
+{
+    private readonly IServiceScopeFactory serviceScopeFactory;
+
+    public FireForgetService(IServiceScopeFactory  serviceScopeFactory)
+    {
+        this.serviceScopeFactory = serviceScopeFactory;
+    }   
+
+    [SuppressMessage("Suggestion", "IDE0063: 'using' statement can be simplified", Justification ="Using simplificado dificulta a leitura")]
+    public void ExecuteWith<T>(Func<T, Task> func) where T: IInjectedService
+    {
+        Task.Run(async () => 
+        {
+            try
+            {
+                await Task.Delay(10000);
+                using(var scope = serviceScopeFactory.CreateScope())
+                {
+                    var userRepo = scope.ServiceProvider.GetRequiredService<T>();
+                    await func(userRepo);
+                    Console.WriteLine("User added after request ended");
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Exemplo de serviço fire and forget para retornos mais rápidos da Web API, com utilização de um novo escopo em uma thread do pool.