### PR TITLE
Xilapa/exemplo feio de comunicação entre threads

### DIFF
--- a/src/WebAPI/AFA.WebAPI/HostedServices/BackgroundTaskQueue.cs
+++ b/src/WebAPI/AFA.WebAPI/HostedServices/BackgroundTaskQueue.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace AFA.WebAPI.HostedServices;
+
+public class BackgroundTaskQueue : IBackgroundTaskQueue
+{
+    private readonly Channel<(Func<CancellationToken,dynamic, Task> func, Type tipo)> queue;
+
+    public BackgroundTaskQueue()
+    {
+        var capacity = Environment.ProcessorCount;
+        var options = new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait
+        };
+        queue = Channel.CreateBounded<(Func<CancellationToken,dynamic, Task> func, Type tipo)>(options);
+    }
+
+    public async Task<(Func<CancellationToken,dynamic,Task> func, Type tipo)> DequeueAsync(CancellationToken stoppingToken)
+    {
+        return await queue.Reader.ReadAsync(stoppingToken);
+    }
+
+
+    public async Task QueueBackgroundWorkItemAsync((Func<CancellationToken,dynamic,Task> func, Type tipo) workItem)
+    {
+        await queue.Writer.WriteAsync(workItem);
+    }
+}

--- a/src/WebAPI/AFA.WebAPI/HostedServices/BackgroundTaskQueue.cs
+++ b/src/WebAPI/AFA.WebAPI/HostedServices/BackgroundTaskQueue.cs
@@ -11,8 +11,7 @@ public class BackgroundTaskQueue : IBackgroundTaskQueue
 
     public BackgroundTaskQueue()
     {
-        var capacity = Environment.ProcessorCount;
-        var options = new BoundedChannelOptions(capacity)
+        var options = new BoundedChannelOptions(128)
         {
             FullMode = BoundedChannelFullMode.Wait
         };

--- a/src/WebAPI/AFA.WebAPI/HostedServices/IBackgroundTaskQueue.cs
+++ b/src/WebAPI/AFA.WebAPI/HostedServices/IBackgroundTaskQueue.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AFA.WebAPI.HostedServices;
+
+public interface IBackgroundTaskQueue 
+{
+    Task QueueBackgroundWorkItemAsync((Func<CancellationToken,dynamic,Task> func, Type tipo) workItem);
+    Task<(Func<CancellationToken,dynamic,Task> func, Type tipo)> DequeueAsync(CancellationToken stoppingToken);
+}

--- a/src/WebAPI/AFA.WebAPI/HostedServices/QueueListenerService.cs
+++ b/src/WebAPI/AFA.WebAPI/HostedServices/QueueListenerService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace AFA.WebAPI.HostedServices;
+
+public class QueueListenerService : BackgroundService
+{
+    private readonly ILogger<QueueListenerService> logger;
+    private readonly IBackgroundTaskQueue backgroundTaskQueue;
+    private readonly IServiceProvider serviceScopeFactory;
+
+    public QueueListenerService(ILogger<QueueListenerService> logger, IBackgroundTaskQueue backgroundTaskQueue, IServiceProvider  serviceScopeFactory)
+    {
+        this.logger = logger;
+        this.backgroundTaskQueue = backgroundTaskQueue;
+        this.serviceScopeFactory = serviceScopeFactory;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Queue listerner is running");
+
+        while(!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(5000, stoppingToken);
+            var (func, tipo) = await  backgroundTaskQueue.DequeueAsync(stoppingToken);
+            logger.LogInformation("Queue listerner tried to DequeueAsync an background work item");
+
+            using(var scope = serviceScopeFactory.CreateScope())
+            {
+                var service = scope.ServiceProvider.GetRequiredService(tipo);
+                await func(stoppingToken, service);
+            }
+
+            logger.LogInformation("Queue listerner fineshed the background work item");
+
+        }
+    }
+}

--- a/src/WebAPI/AFA.WebAPI/HostedServices/TimedService.cs
+++ b/src/WebAPI/AFA.WebAPI/HostedServices/TimedService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AFA.Domain.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using AFA.Domain.Entities;
+
+namespace AFA.WebAPI.HostedServices;
+
+public class TimedService : IHostedService
+{
+    private readonly ILogger<TimedService> logger;
+    private readonly IBackgroundTaskQueue taskQueue;
+
+    public TimedService(ILogger<TimedService> logger, IBackgroundTaskQueue taskQueue)
+    {
+        this.logger = logger;
+        this.taskQueue = taskQueue;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Starting de hosted service");
+        var exectuingTask = ExecuteAsync(cancellationToken);
+
+        if(exectuingTask.IsCompleted)
+            return exectuingTask;
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+
+    private async Task ExecuteAsync(CancellationToken cancellationToken)
+    {   
+        while (!cancellationToken.IsCancellationRequested)
+        {                
+            logger.LogInformation("Background Task enqueued started at {time}", DateTime.Now);
+
+            Func<CancellationToken, dynamic, Task> funcao = async (token, objeto) =>
+                        {
+                            var newId = Guid.NewGuid();
+                            var userNovo = new User("nome", "email") { Id = newId };
+                            objeto.Add(userNovo);
+
+                            await (objeto.UoW.SaveChangesAsync() as Task<int>);
+                            logger.LogInformation("Background Task Id: {id} executed at {time}", newId, DateTime.Now);
+                        };
+
+            await taskQueue.QueueBackgroundWorkItemAsync(
+                (
+                    func: funcao, 
+                    tipo: typeof(IUserRepository)
+                )
+            );
+
+            logger.LogInformation("Background Task enqueued finished at {time}", DateTime.Now);
+            await Task.Delay(10000, cancellationToken);
+
+        }        
+    }
+}

--- a/src/WebAPI/AFA.WebAPI/Startup.cs
+++ b/src/WebAPI/AFA.WebAPI/Startup.cs
@@ -8,6 +8,7 @@ using AFA.WebAPI.Extensions;
 using AFA.Infra.Extensions;
 using AFA.Infra.Data;
 using Microsoft.AspNetCore.Mvc;
+using AFA.WebAPI.HostedServices;
 
 namespace AFA.WebAPI;
 
@@ -34,6 +35,10 @@ public class Startup : IStartup
         services.AddDomainServices();
         services.AddApplicationServices();
         services.AddApplicationFluentValidations();
+
+        services.AddHostedService<TimedService>();
+        services.AddHostedService<QueueListenerService>();
+        services.AddSingleton<IBackgroundTaskQueue, BackgroundTaskQueue>();
     }
 
     // Configure the HTTP request pipeline.


### PR DESCRIPTION
Exemplo de comunicação entre threads usando Channel e criação de um novo escopo.
O exemplo é feio por utilizar propriedades dynamic.